### PR TITLE
hotfix: 기준 status 별 음악 랜덤 조회 1개하기.

### DIFF
--- a/api/controllers/music.controller.js
+++ b/api/controllers/music.controller.js
@@ -62,20 +62,20 @@ class MusicController {
     try {
       let { survey } = req.params;
       if (survey == 1) {
-        let survey1 = await this.musicRepository.findBySurvey1({
+        let result = await this.musicService.findBySurvey1({
           status: [4, 7, 8],
         });
-        return res.status(200).json({ survey1 });
+        return res.status(200).json({ result });
       } else if (survey == 2) {
-        let survey2 = await this.musicService.findBySurvey2({
+        let result = await this.musicService.findBySurvey2({
           status: 5,
         });
-        return res.status(200).json({ survey2 });
+        return res.status(200).json({ result });
       } else if (survey == 3) {
-        let survey3 = await this.musicRepository.findBySurvey3({
+        let result = await this.musicRepository.findBySurvey3({
           status: [2, 3, 6],
         });
-        return res.status(200).json({ survey3 });
+        return res.status(200).json({ result });
       } else return res.status(400).json({ msg: "invalid survey parameters." });
     } catch (err) {
       next(err);

--- a/api/repositories/music.repository.js
+++ b/api/repositories/music.repository.js
@@ -1,10 +1,13 @@
 const { Musics, Composers } = require("../../db/models");
 const { S3 } = require("aws-sdk");
 const Sequelize = require("sequelize");
-const { Op } = require('sequelize');
+const { Op } = require("sequelize");
 
 class MusicRepository {
   constructor() {}
+  rand(min, max) {
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+  }
   create = async ({
     musicTitle,
     musicContent,
@@ -71,7 +74,6 @@ class MusicRepository {
   };
   findBySurvey1 = async () => {
     let survey1 = await Musics.findAll({
-      order: Sequelize.literal("rand()"),
       where: { status: [4, 7, 8] },
       attributes: ["musicId", "musicTitle", "composer", "musicUrl", "fileName"],
     });
@@ -79,7 +81,6 @@ class MusicRepository {
   };
   findBySurvey2 = async () => {
     let survey2 = await Musics.findAll({
-      order: Sequelize.literal("rand()"),
       where: { status: 5 },
       attributes: ["musicId", "musicTitle", "composer", "musicUrl", "fileName"],
     });
@@ -87,33 +88,32 @@ class MusicRepository {
   };
   findBySurvey3 = async () => {
     let survey3 = await Musics.findAll({
-      order: Sequelize.literal("rand()"),
       where: { status: [2, 3, 6] },
       attributes: ["musicId", "musicTitle", "composer", "musicUrl", "fileName"],
     });
     return survey3;
   };
   findByKeyword = async ({ keyword }) => {
-    console.log(keyword)
+    console.log(keyword);
     const composerInfo = await Composers.findOne({
       where: {
-        composer: { [Op.like]: `%${keyword}%` } 
+        composer: { [Op.like]: `%${keyword}%` },
       },
-    })
+    });
     const composerSong = await Musics.findAll({
       where: {
-        composer: { [Op.like]: `%${keyword}%` } 
+        composer: { [Op.like]: `%${keyword}%` },
       },
-      order: [['musicTitle', 'DESC']],
+      order: [["musicTitle", "DESC"]],
     });
     const musicTitle = await Musics.findAll({
       where: {
-        musicTitle: { [Op.like]: `%${keyword}%` } 
+        musicTitle: { [Op.like]: `%${keyword}%` },
       },
-      order: [['musicTitle', 'DESC']],
+      order: [["musicTitle", "DESC"]],
     });
 
-    const search = {composerInfo, composerSong, musicTitle}
+    const search = { composerInfo, composerSong, musicTitle };
     return search;
   };
 }

--- a/api/services/music.service.js
+++ b/api/services/music.service.js
@@ -5,6 +5,7 @@ class MusicService {
   constructor() {
     this.musicRepository = new musicRepository();
   }
+
   findOneByMusicId = async ({ musicId }) => {
     let music = await this.musicRepository.findOneByMusicId({ musicId });
     if (music == null) {
@@ -49,48 +50,54 @@ class MusicService {
   };
   findBySurvey1 = async () => {
     let survey1 = await this.musicRepository.findBySurvey1();
-    for (let i = 0; i < survey1.length; i++) {
-      let fileName = survey1[i].dataValues.fileName;
-      survey1[i].dataValues.musicUrl =
-        "https://d13uh5mnneeyhq.cloudfront.net/" + fileName;
-    }
     if (survey1 == "") {
       throw new makeError({
         message: "status 4,7,8 에 해당하는 음악이 없습니다.",
         code: 400,
       });
     }
-    return survey1;
+    for (let i = 0; i < survey1.length; i++) {
+      let fileName = survey1[i].dataValues.fileName;
+      survey1[i].dataValues.musicUrl =
+        "https://d13uh5mnneeyhq.cloudfront.net/" + fileName;
+    }
+    let randNum = await this.musicRepository.rand(0, survey1.length);
+    let randOne = survey1[randNum].dataValues;
+    return randOne;
   };
   findBySurvey2 = async () => {
     let survey2 = await this.musicRepository.findBySurvey2();
-    for (let i = 0; i < survey2.length; i++) {
-      let fileName = survey2[i].dataValues.fileName;
-      survey2[i].dataValues.musicUrl =
-        "https://d13uh5mnneeyhq.cloudfront.net/" + fileName;
-    }
     if (survey2 == "") {
       throw new makeError({
         message: "status: 5 에 해당하는 음악이 없습니다.",
         code: 400,
       });
     }
-    return survey2;
+    for (let i = 0; i < survey2.length; i++) {
+      let fileName = survey2[i].dataValues.fileName;
+      survey2[i].dataValues.musicUrl =
+        "https://d13uh5mnneeyhq.cloudfront.net/" + fileName;
+    }
+    let randNum = await this.musicRepository.rand(0, survey2.length);
+    let randOne = survey2[randNum].dataValues;
+    return randOne;
   };
   findBySurvey3 = async () => {
     let survey3 = await this.musicRepository.findBySurvey3();
-    for (let i = 0; i < survey3.length; i++) {
-      let fileName = survey3[i].dataValues.fileName;
-      survey3[i].dataValues.musicUrl =
-        "https://d13uh5mnneeyhq.cloudfront.net/" + fileName;
-    }
     if (survey3 == "") {
       throw new makeError({
         message: "status: 2,3,6 에 해당하는 음악이 없습니다.",
         code: 400,
       });
     }
-    return survey3;
+    for (let i = 0; i < survey3.length; i++) {
+      let fileName = survey3[i].dataValues.fileName;
+      survey3[i].dataValues.musicUrl =
+        "https://d13uh5mnneeyhq.cloudfront.net/" + fileName;
+    }
+    let randNum = await this.musicRepository.rand(0, survey3.length);
+    let randOne = survey3[randNum].dataValues;
+    return randOne;
   };
   findByKeyword = async ({ keyword }) => {
     const music = await this.musicRepository.findByKeyword({ keyword });
@@ -106,6 +113,6 @@ class MusicService {
         code: 400,
       });
     }
-  }
+  };
 }
 module.exports = MusicService;


### PR DESCRIPTION
hotfix: 프론트 재욱님과 대화 후 알고보니 음악 전부 전송하는 것이 아니라, 1개만 랜덤하게 찾아서 달라고 하시네요. 
긴급하게 수정하고 PR 올립니다.
기존: 
status 별 음악 랜덤 조회 후 조회된 음악 전부 GET 전송
서비스 층에서 에러가 잡히지 않는 문제
변경:
 + 기준 status 별 음악 랜덤하게 하나 조회 GET 전송
 + 서비스 층에서 에러 잡는 if문 위치 변경을 통해 해결