### PR TITLE
fix: 노래 음악 조회하는곳에 클라우드 프론트 추가

### DIFF
--- a/api/controllers/music.controller.js
+++ b/api/controllers/music.controller.js
@@ -66,8 +66,10 @@ class MusicController {
   };
   findByKeyword = async (req, res, next) => {
     try {
+      const { userId } = res.locals.user;
       const { keyword } = req.query;
       const project = await this.musicService.findByKeyword({
+        userId,
         keyword,
       });
       return res.status(200).json({ data: project });

--- a/api/repositories/music.repository.js
+++ b/api/repositories/music.repository.js
@@ -87,11 +87,19 @@ class MusicRepository {
     };
     return s3.upload(param).promise();
   };
-  //ㅡㅡㅡㅡㅡ교점 없음
+
   findOneByStatus = async (status) => {
     const mood = await Musics.findOne({
       order: Sequelize.literal("rand()"),
       where: { status },
+      // include: [
+      //   {
+      //     model: Composers,
+      //     as: "Composer",
+      //     targetKey: "composer",
+      //     attributes: ["imageUrl"],
+      //   },
+      // ],
     });
     return mood;
   };

--- a/api/routes/music.routes.js
+++ b/api/routes/music.routes.js
@@ -7,7 +7,7 @@ const MusicController = require("../controllers/music.controller");
 const musicController = new MusicController();
 
 router.post("/music", multer({ storage }).any(), musicController.create);
-router.get("/music/search", musicController.findByKeyword);
+router.get("/music/search",statusMiddleWare, musicController.findByKeyword);
 router.get("/music", statusMiddleWare, musicController.findAllByComposer);
 router.get("/music/mood/:x/:y", musicController.findAllByCoOrdinates);
 router.get("/music/survey/:x/:y", musicController.findAllByCoOrdinates);

--- a/api/services/music.service.js
+++ b/api/services/music.service.js
@@ -45,7 +45,7 @@ class MusicService {
         userId,
         music.music[i].musicId
       );
-      music.music[i].dataValues.scrapStatus = !!scrap
+      music.music[i].dataValues.scrapStatus = !!scrap;
     }
     return await cloudfrontfor(music);
   };
@@ -208,6 +208,13 @@ class MusicService {
       music.composerSong[i].dataValues.likeStatus = !!like;
       const scrap = await this.scrapRepository.findScrap(userId, musicId);
       music.composerSong[i].dataValues.scrapStatus = !!scrap;
+    }
+    for (let i = 0; i < music.musicTitle.length; i++) {
+      const musicId = music.musicTitle[i].dataValues.musicId;
+      const like = await this.likeRepository.findLike(userId, musicId);
+      music.musicTitle[i].dataValues.likeStatus = !!like;
+      const scrap = await this.scrapRepository.findScrap(userId, musicId);
+      music.musicTitle[i].dataValues.scrapStatus = !!scrap;
     }
     return music;
   };

--- a/api/services/music.service.js
+++ b/api/services/music.service.js
@@ -182,7 +182,9 @@ class MusicService {
     const composerImage = await this.composerRepository.getComposer({
       composer: musicData.dataValues.composer,
     });
-    musicData.dataValues.imageUrl = composerImage.dataValues.imageUrl;
+    musicData.dataValues.imageUrl =
+      "https://d13uh5mnneeyhq.cloudfront.net/" +
+      composerImage.dataValues.imageUrl;
     return { musicData, message };
   };
 

--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use("/api", router);
 
 app.use((error, req, res, next) => {
-  console.error(error);
+  logger.error(error);
   return res
     .status(error.code || 500)
     .json({ message: error.message || "서버 에러." });

--- a/app.js
+++ b/app.js
@@ -51,7 +51,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use("/api", router);
 
 app.use((error, req, res, next) => {
-  logger.error(error);
+  console.error(error);
   return res
     .status(error.code || 500)
     .json({ message: error.message || "서버 에러." });


### PR DESCRIPTION
현재 Composers 와 Musics의 관계설정이 model에만 되있고 migration에는 안되있어서 수동으로 찾아서 넣어주는 로직입니다.