### PR TITLE
fix: 작곡가, 음악 관계설정 모델변경, fileName 삭제로 인한 로직 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.json
 .env
 logs
 *.log
+email.js

--- a/api/controllers/mail.controller.js
+++ b/api/controllers/mail.controller.js
@@ -1,0 +1,38 @@
+const createTransporter = require("../../db/config/email");
+const transporter = createTransporter();
+
+class mailController {
+  constructor() {}
+
+  mailCheck = async (req, res, next) => {
+    try {
+      const { email } = req.body;
+      const password = Math.floor(Math.random() * 1000000);; // 6자리 랜덤한 비밀번호 생성
+      let mailOptions = {
+        from: "MoodClassic99@gmail.com", //송신할 이메일
+        to: email, //수신할 이메일
+        subject: "MOOD 확인 코드입니다.",
+        html: `
+         <div>
+             <h2>Mood Code</h2>
+             <div class="phone" style="font-size: 1.1em;">Title : "코드를 Mood 홈페이지에 입력하세요."</div>
+             <div class="message" style="font-size: 1.1em;">message : ${password}</div>
+         </div>
+         `,
+      };
+      await transporter.sendMail(mailOptions, function (error, info) {
+        if (error) {
+          console.log(error);
+        } else {
+          console.log("Email sent: " + info.response);
+        }
+      });
+      return res.json({ message: "성공적", password: password }); // 비밀번호를 res에 담아 보내줍니다.
+    } catch (err) {
+      console.error(err);
+      next(err);
+    }
+  };
+}
+
+module.exports = mailController;

--- a/api/controllers/music.controller.js
+++ b/api/controllers/music.controller.js
@@ -11,8 +11,7 @@ class MusicController {
       let file = req.files[0];
       let data = await this.musicRepository.s3Upload(file);
       let fileName = data.Key;
-      let { musicTitle, musicContent, status, composer, tag } =
-        req.body;
+      let { musicTitle, musicContent, status, composer, tag } = req.body;
       let music = await this.musicService.create({
         musicTitle,
         musicContent,

--- a/api/repositories/music.repository.js
+++ b/api/repositories/music.repository.js
@@ -25,14 +25,14 @@ class MusicRepository {
     return music;
   };
   createTag = async ({ musicId, tag }) => {
-      const tags = await Tags.findOrCreate({
-        where: { tagName: tag.trim() },
-      });
-      await MusicTags.create({
-        musicId,
-        tagId: tags[0].tagId,
-      });
-    }
+    const tags = await Tags.findOrCreate({
+      where: { tagName: tag.trim() },
+    });
+    await MusicTags.create({
+      musicId,
+      tagId: tags[0].tagId,
+    });
+  };
   findOneByMusicId = async ({ musicId }) => {
     let music = await Musics.findOne({
       where: { musicId },

--- a/api/repositories/music.repository.js
+++ b/api/repositories/music.repository.js
@@ -14,42 +14,25 @@ const redisClient = require("../../db/config/redisClient");
 
 class MusicRepository {
   constructor() {}
-  create = async ({
-    musicTitle,
-    musicContent,
-    status,
-    composer,
-    tag,
-    musicUrl,
-  }) => {
+  create = async ({ musicTitle, musicContent, status, composer, musicUrl }) => {
     let music = await Musics.create({
       musicTitle,
       musicContent,
       status,
       composer,
-      tag,
       musicUrl,
     });
-    if (tag) {
-      const tagList = tag.split(",");
-      for (const tag of tagList) {
-        const tags = await Tags.findOrCreate({
-          where: { tagName: tag.trim() },
-        });
-        const musicTags = await MusicTags.create({
-          musicId: music.musicId,
-          tagId: tags[0].tagId,
-        });
-        if (!musicTags) {
-          throw new makeError({
-            message: "태그 생성에 실패하였습니다.",
-            code: 400,
-          });
-        }
-      }
-    }
     return music;
   };
+  createTag = async ({ musicId, tag }) => {
+      const tags = await Tags.findOrCreate({
+        where: { tagName: tag.trim() },
+      });
+      await MusicTags.create({
+        musicId,
+        tagId: tags[0].tagId,
+      });
+    }
   findOneByMusicId = async ({ musicId }) => {
     let music = await Musics.findOne({
       where: { musicId },
@@ -59,7 +42,6 @@ class MusicRepository {
         "composer",
         "musicUrl",
         "musicId",
-        "fileName",
       ],
     });
     return music;
@@ -119,7 +101,6 @@ class MusicRepository {
         "composer",
         "musicTitle",
         "musicContent",
-        "fileName",
         "musicUrl",
       ],
     });
@@ -149,7 +130,6 @@ class MusicRepository {
         "composer",
         "musicTitle",
         "musicContent",
-        "fileName",
         "musicUrl",
         "tag",
       ],
@@ -164,7 +144,6 @@ class MusicRepository {
         "musicTitle",
         "composer",
         "musicUrl",
-        "fileName",
         [Sequelize.fn("COUNT", Sequelize.col("Likes.musicId")), "likesCount"],
       ],
       include: [
@@ -189,7 +168,6 @@ class MusicRepository {
         "musicTitle",
         "composer",
         "musicUrl",
-        "fileName",
         [
           Sequelize.fn("COUNT", Sequelize.col("Streamings.musicId")),
           "streamingCount",
@@ -216,7 +194,6 @@ class MusicRepository {
   };
 
   tagMusicId = async ({ musicId, tag }) => {
-    console.log(tag);
     const tagList = tag.split(",");
     for (const tag of tagList) {
       const tags = await Tags.findOrCreate({

--- a/api/repositories/music.repository.js
+++ b/api/repositories/music.repository.js
@@ -131,7 +131,6 @@ class MusicRepository {
         "musicTitle",
         "musicContent",
         "musicUrl",
-        "tag",
       ],
     });
     return { composerInfo, composerSong, musicTitle };

--- a/api/repositories/user.repository.js
+++ b/api/repositories/user.repository.js
@@ -101,7 +101,6 @@ class UserRepository {
         "composer",
         "musicUrl",
         "musicId",
-        "fileName",
       ],
       limit: 10,
       offset: (page - 1) * 10,

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -7,8 +7,9 @@ const ReCommentRouter = require("./recomment.routes");
 const Composer = require("./composer.routes")
 const LikeRouter = require("./like.route");
 const ScrapRouter = require("./scrap.route");
+const MailRouter = require("./mail.routes")
 
-router.use("/", UserRouter);
+router.use("/", UserRouter, MailRouter);
 router.use("/review", ReCommentRouter);
 router.use("/music", [ScrapRouter, LikeRouter, ReviewRouter]);
 router.use("/", MusicRouter, Composer);

--- a/api/routes/mail.routes.js
+++ b/api/routes/mail.routes.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+
+const MailController = require("../controllers/mail.controller");
+const mailController = new MailController();
+
+router.get("/user/email", mailController.mailCheck);
+
+module.exports = router;

--- a/api/routes/music.routes.js
+++ b/api/routes/music.routes.js
@@ -7,7 +7,7 @@ const MusicController = require("../controllers/music.controller");
 const musicController = new MusicController();
 
 router.post("/music", multer({ storage }).any(), musicController.create);
-router.get("/music/search",statusMiddleWare, musicController.findByKeyword);
+router.get("/music/search", statusMiddleWare, musicController.findByKeyword);
 router.get("/music", statusMiddleWare, musicController.findAllByComposer);
 router.get("/music/mood/:x/:y", musicController.findAllByCoOrdinates);
 router.get("/music/survey/:x/:y", musicController.findAllByCoOrdinates);
@@ -19,6 +19,6 @@ router.post(
   musicController.sendStreaming
 );
 router.get("/music/:musicId", musicController.findOneByMusicId);
-router.patch("/music/:musicId/tag", musicController.tagMusicId)
+router.patch("/music/:musicId/tag", musicController.tagMusicId);
 
 module.exports = router;

--- a/api/routes/music.routes.js
+++ b/api/routes/music.routes.js
@@ -7,8 +7,8 @@ const MusicController = require("../controllers/music.controller");
 const musicController = new MusicController();
 
 router.post("/music", multer({ storage }).any(), musicController.create);
-router.get("/music/search", statusMiddleWare, musicController.findByKeyword);
-router.get("/music", statusMiddleWare, musicController.findAllByComposer);
+router.get("/music/search", musicController.findByKeyword);
+router.get("/music", musicController.findAllByComposer);
 router.get("/music/mood/:x/:y", musicController.findAllByCoOrdinates);
 router.get("/music/survey/:x/:y", musicController.findAllByCoOrdinates);
 router.get("/music/likechart", statusMiddleWare, musicController.likeChart);

--- a/api/services/music.service.js
+++ b/api/services/music.service.js
@@ -46,8 +46,6 @@ class MusicService {
         code: 400,
       });
     }
-    let fileName = music.fileName;
-    music.musicUrl = "https://d13uh5mnneeyhq.cloudfront.net/" + fileName;
     return music;
   };
   findAllByComposer = async ({ userId, composer }) => {

--- a/api/services/music.service.js
+++ b/api/services/music.service.js
@@ -29,9 +29,13 @@ class MusicService {
       musicContent,
       status,
       composer,
-      tag,
       musicUrl,
     });
+    const musicId = music.musicId;
+    const tagList = tag.split(",");
+    for (const tag of tagList) {
+      await this.musicRepository.createTag({ musicId, tag });
+    }
     return music;
   };
   findOneByMusicId = async ({ musicId }) => {

--- a/db/migrations/20230311014341-create-composers.js
+++ b/db/migrations/20230311014341-create-composers.js
@@ -3,15 +3,10 @@
 module.exports = {
   async up(queryInterface, Sequelize) {
     await queryInterface.createTable("Composers", {
-      composerId: {
-        allowNull: false,
-        autoIncrement: true,
-        primaryKey: true,
-        type: Sequelize.INTEGER,
-      },
       composer: {
         type: Sequelize.STRING,
         allowNull: false,
+        primaryKey: true,
       },
       describe: {
         type: Sequelize.STRING,

--- a/db/migrations/20230311014355-create-musics.js
+++ b/db/migrations/20230311014355-create-musics.js
@@ -38,14 +38,6 @@ module.exports = {
         },
         onDelete: "CASCADE",
       },
-      fileName: {
-        type: Sequelize.STRING,
-        allowNull: false,
-      },
-      tag: {
-        type: Sequelize.STRING,
-        allowNull: true,
-      },
     });
   },
   async down(queryInterface, Sequelize) {

--- a/db/migrations/20230311014355-create-musics.js
+++ b/db/migrations/20230311014355-create-musics.js
@@ -21,10 +21,6 @@ module.exports = {
         type: Sequelize.STRING,
         allowNull: false,
       },
-      tag: {
-        type: Sequelize.JSON,
-        allowNull: true,
-      },
       status: {
         type: Sequelize.INTEGER,
         allowNull: false,

--- a/db/migrations/20230311014425-create-chats.js
+++ b/db/migrations/20230311014425-create-chats.js
@@ -13,7 +13,7 @@ module.exports = {
         allowNull: false,
         type: Sequelize.INTEGER,
       },
-      nickname: { //소셜로그인이 어떨지 모르겠네 model도
+      nickname: {
         type: Sequelize.STRING,
       },
       message: {

--- a/db/migrations/20230323053417-create-MusicTags.js
+++ b/db/migrations/20230323053417-create-MusicTags.js
@@ -12,6 +12,11 @@ module.exports = {
       musicId: {
         allowNull: false,
         type: Sequelize.INTEGER,
+        references: {
+          model: "Musics",
+          key: "musicId",
+        },
+        onDelete: "CASCADE",
       },
       tagId: {
         allowNull: false,

--- a/db/models/chats.js
+++ b/db/models/chats.js
@@ -22,7 +22,6 @@ module.exports = (sequelize, DataTypes) => {
         unique: true,
       },
       nickname: {
-        //소셜로그인이 어떨지 모르겠네 migration도
         type: DataTypes.STRING,
         allowNull: false,
         unique: true,

--- a/db/models/composers.js
+++ b/db/models/composers.js
@@ -17,15 +17,10 @@ module.exports = (sequelize, DataTypes) => {
   }
   Composers.init(
     {
-      composerId: {
-        allowNull: false,
-        autoIncrement: true,
-        primaryKey: true,
-        type: DataTypes.INTEGER,
-      },
       composer: {
         type: DataTypes.STRING,
         allowNull: false,
+        primaryKey: true,
       },
       describe: {
         type: DataTypes.STRING,

--- a/db/models/musics.js
+++ b/db/models/musics.js
@@ -63,14 +63,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         allowNull: false,
       },
-      fileName: {
-        type: DataTypes.STRING,
-        allowNull: false,
-      },
-      tag: {
-        type: DataTypes.JSON,
-        allowNull: true,
-      },
     },
     {
       sequelize,

--- a/db/models/users.js
+++ b/db/models/users.js
@@ -13,7 +13,10 @@ module.exports = (sequelize, DataTypes) => {
         sourceKey: "userId",
         foreignKey: "userId",
       });
-
+      this.hasMany(models.ReComments, {
+        sourceKey: "userId",
+        foreignKey: "userId",
+      });
       this.hasOne(models.UserInfos, {
         sourceKey: "userId",
         foreignKey: "userId",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "multer": "^1.4.5-lts.1",
         "multer-s3": "^3.0.1",
         "mysql2": "^3.1.2",
+        "nodemailer": "^6.9.1",
         "sequelize": "^6.29.0",
         "socket.io": "^4.6.1",
         "uuid": "^9.0.0",
@@ -3721,6 +3722,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.1.tgz",
+      "integrity": "sha512-qHw7dOiU5UKNnQpXktdgQ1d3OFgRAekuvbJLcdG5dnEo/GtcTHRYM7+UfJARdOFU9WUQO8OiIamgWPmiSFHYAA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "multer": "^1.4.5-lts.1",
     "multer-s3": "^3.0.1",
     "mysql2": "^3.1.2",
+    "nodemailer": "^6.9.1",
     "sequelize": "^6.29.0",
     "socket.io": "^4.6.1",
     "uuid": "^9.0.0",


### PR DESCRIPTION
중복 적용됐던, 음악 url을 하나로 줄이니 attribute에서 사용하던 것들에서 오류가 날겁니다.
각자 로직 확인 필요합니다.

작곡가 composerId 삭제하고 composer을 primary key로 등록하여 음악과 연결하였습니다.

음악에서 tag, fileName이 삭제되었습니다. 

대댓글에 user와 관계설정을 추가하였습니다.

findOneByMusicId에 fileName 부분 수정하였습니다. 클라우드 프론트 2번씌워져서 

findAllByComposer,findOneByMusicId 검사했습니다. 